### PR TITLE
Release v0.3.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,21 @@ let package = Package(
             url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/CustomMenuKit.xcframework.zip",
             checksum: "323803e9a42211af91a8e411e85692f34443805edaf4bab22c2c0278094ab4b9"
         ),
+        .binaryTarget(
+            name: "Alamofire",
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/Alamofire.xcframework.zip",
+            checksum: "0b23fdba213d4088cc04219b6b3f0fbd5d1e7f9236213469b96058c439b9c296"
+        ),
+        .binaryTarget(
+            name: "Cloneable_Swift_Client",
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/Cloneable_Swift_Client.xcframework.zip",
+            checksum: "5fbb87fdf2ab3425a6289617689dcd19b3cf7198ba83f524b5e852384f3c4ce5"
+        ),
+        .binaryTarget(
+            name: "SQLite",
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/SQLite.xcframework.zip",
+            checksum: "e8ce658734743c92004efcaadf601c5d72d01aab68adff1bd56ba89f4d38250d"
+        ),
         .target(
             name: "CloneableResources",
             dependencies: ["CloneablePlatformiOS"],

--- a/Package.swift
+++ b/Package.swift
@@ -1,126 +1,45 @@
 // swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
     name: "Cloneable-iOS-SDK",
+    platforms: [
+        .iOS(.v17)
+    ],
     products: [
         .library(
-            name: "Cloneable-iOS-SDK",
-            targets: [
-                "Alamofire",
-                "AnyCodable",
-                "ArcGIS",
-                "Auth0",
-                "CloneableCore",
-                "CloneablePlatformiOS",
-                "Cloneable_Swift_Client",
-                "CoreArcGIS",
-                "JWTDecode",
-                "JXKit",
-                "MCByteTrack",
-                "PopupView",
-                "Roboflow",
-                "SQLite",
-                "SimpleKeychain",
-                "cxxLibrary",
-                "CloneableResources"
-            ]
+            name: "CloneablePlatformiOS",
+            targets: ["CloneablePlatformiOS", "CloneableResources"]
         ),
-    ],
-    dependencies: [
-        // No package dependencies
     ],
     targets: [
-        .target(
-            name: "CloneableResources",
-            dependencies: ["CloneablePlatformiOS"],
-            resources: [
-                .process("Assets.car"),
-                .copy("default.metallib")
-            ]
-        ),
-        .binaryTarget(
-            name: "Alamofire",
-            url: "https://files.cloneable.ai/0.2.01/Alamofire.xcframework.zip",
-            checksum: "78a11389939f7e552b042ca9fdb7bb4d8a4d0be248d82fd449237b13c540ddff"
-        ),
-        .binaryTarget(
-            name: "AnyCodable",
-            url: "https://files.cloneable.ai/0.2.01/AnyCodable.xcframework.zip",
-            checksum: "94141753c7455e0afc0ac9a47d3780729cb824a2bc5f37320d51fb9d8f984b7d"
-        ),
-        .binaryTarget(
-            name: "ArcGIS",
-            url: "https://files.cloneable.ai/0.2.01/ArcGIS.xcframework.zip",
-            checksum: "b0a8f29b544aa2da4d341d6fe3d8e6730ba883c6aa5331b4119823fb288d186d"
-        ),
-        .binaryTarget(
-            name: "Auth0",
-            url: "https://files.cloneable.ai/0.2.01/Auth0.xcframework.zip",
-            checksum: "0238f6b85d8dce653bec9df8ddd133a2248e89239f71c1e273a228052916fe17"
-        ),
-        .binaryTarget(
-            name: "CloneableCore",
-            url: "https://files.cloneable.ai/0.2.01/CloneableCore.xcframework.zip",
-            checksum: "d7b0966311f2c70bb6e32e7b271e054a1c114389a0e4549c1480ed0bac5d9c93"
-        ),
         .binaryTarget(
             name: "CloneablePlatformiOS",
-            url: "https://files.cloneable.ai/0.2.01/CloneablePlatformiOS.xcframework.zip",
-            checksum: "0afa3e48bfc22e3d4defb1669b4c483206b6fee7f049b33665871f1b98062e1f"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/CloneablePlatformiOS.xcframework.zip",
+            checksum: "995ad44a4eb121af23c40a45285ab566da60d220578d08e9fa1fcfdd880f9e0f"
         ),
         .binaryTarget(
-            name: "Cloneable_Swift_Client",
-            url: "https://files.cloneable.ai/0.2.01/Cloneable_Swift_Client.xcframework.zip",
-            checksum: "2f6fb92f62b23bb1b9989242de1667650053eff9195e79f90aa2e136b59acd46"
-        ),
-        .binaryTarget(
-            name: "CoreArcGIS",
-            url: "https://files.cloneable.ai/0.2.01/CoreArcGIS.xcframework.zip",
-            checksum: "a9693f3389fe4a78498ad42ea74973b7727cdb30bb42d9ae8227c2d1a0b42cc2"
-        ),
-        .binaryTarget(
-            name: "JWTDecode",
-            url: "https://files.cloneable.ai/0.2.01/JWTDecode.xcframework.zip",
-            checksum: "f71a8b97df96df4df5e529b4d4a5d9b23ddfec1c810212cfe231eac9155dc6d0"
+            name: "CloneableCore", 
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/CloneableCore.xcframework.zip",
+            checksum: "6ef0fde34946be9b90a37f09136762acdc5b55edaa40a75fcab5a1f0e78dcbe7"
         ),
         .binaryTarget(
             name: "JXKit",
-            url: "https://files.cloneable.ai/0.2.01/JXKit.xcframework.zip",
-            checksum: "2430a73997cfced87fbeeeb18be2a3f6d947c89c57b95cdf867fd9f4ad06e69a"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/JXKit.xcframework.zip", 
+            checksum: "bdee7ff79776d99cce75b3e8247821939696db4271330860f6b2c8a4f476dacb"
         ),
         .binaryTarget(
-            name: "MCByteTrack",
-            url: "https://files.cloneable.ai/0.2.01/MCByteTrack.xcframework.zip",
-            checksum: "bd8dba0fd56c6d28f965bcacbdabd9129f710a4420fcbb2bb6fca38c44df4c54"
+            name: "CustomMenuKit",
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/v0.3.10/CustomMenuKit.xcframework.zip",
+            checksum: "323803e9a42211af91a8e411e85692f34443805edaf4bab22c2c0278094ab4b9"
         ),
-        .binaryTarget(
-            name: "PopupView",
-            url: "https://files.cloneable.ai/0.2.01/PopupView.xcframework.zip",
-            checksum: "7a4f345a9830cd4ff15832448c3858e0c91d31fcc0523105678b55e240acbeea"
-        ),
-        .binaryTarget(
-            name: "Roboflow",
-            url: "https://files.cloneable.ai/0.2.01/Roboflow.xcframework.zip",
-            checksum: "6b7e39313acf280dfe8859c52e089d350dfbaaf07b68e6dd34191c1ac1a39c3e"
-        ),
-        .binaryTarget(
-            name: "SQLite",
-            url: "https://files.cloneable.ai/0.2.01/SQLite.xcframework.zip",
-            checksum: "f1c725d5df6855c4dfde3e0081076bdf0d956faedfbff11445a4efe589230ea0"
-        ),
-        .binaryTarget(
-            name: "SimpleKeychain",
-            url: "https://files.cloneable.ai/0.2.01/SimpleKeychain.xcframework.zip",
-            checksum: "a5ba0d42d5b14c581d336a506ce37b4ae3193242d6fa26644cddb8311d6c0aea"
-        ),
-        .binaryTarget(
-            name: "cxxLibrary",
-            url: "https://files.cloneable.ai/0.2.01/cxxLibrary.xcframework.zip",
-            checksum: "2acf05ebf45fb35a5320d54aad3e123e446b25bfe51af2700c7371381c1fbcaa"
+        .target(
+            name: "CloneableResources",
+            dependencies: ["CloneablePlatformiOS"],
+            path: "Sources/CloneableResources",
+            resources: [
+                .process(".")
+            ]
         )
-
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "CloneablePlatformiOS",
+            name: "Cloneable-iOS-SDK",
             targets: [
                 "Alamofire",
                 "CloneableCore", 

--- a/Package.swift
+++ b/Package.swift
@@ -36,9 +36,9 @@ let package = Package(
         .target(
             name: "CloneableResources",
             dependencies: ["CloneablePlatformiOS"],
-            path: "Sources/CloneableResources",
             resources: [
-                .process(".")
+                .copy("Assets.car"),
+                .copy("default.metallib")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,16 @@ let package = Package(
     products: [
         .library(
             name: "CloneablePlatformiOS",
-            targets: ["CloneablePlatformiOS", "CloneableResources"]
+            targets: [
+                "Alamofire",
+                "CloneableCore", 
+                "CloneablePlatformiOS",
+                "Cloneable_Swift_Client",
+                "CustomMenuKit",
+                "JXKit",
+                "SQLite",
+                "CloneableResources"
+            ]
         ),
     ],
     targets: [


### PR DESCRIPTION
## SDK Release v0.3.10

Auto-generated Package.swift update for new SDK release.

### Changes
- Updated binary target URLs to point to release v0.3.10
- Updated checksums for all frameworks:
  - CloneablePlatformiOS: `995ad44a4eb121af23c40a45285ab566da60d220578d08e9fa1fcfdd880f9e0f`
  - CloneableCore: `6ef0fde34946be9b90a37f09136762acdc5b55edaa40a75fcab5a1f0e78dcbe7`
  - JXKit: `bdee7ff79776d99cce75b3e8247821939696db4271330860f6b2c8a4f476dacb`
  - CustomMenuKit: `323803e9a42211af91a8e411e85692f34443805edaf4bab22c2c0278094ab4b9`

### Release Assets
All frameworks have been uploaded to: https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/tag/v0.3.10

### Testing
- [ ] Verify release assets are accessible
- [ ] Test Package.swift syntax is valid  
- [ ] Confirm checksums match uploaded files

Source: CloneablePlatformiOS@ce47847ce3488bd6cb21f234db2c3bc2ff8a6dde