### PR TITLE
Release 1.0.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,38 +24,38 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "CloneablePlatformiOS",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/CloneablePlatformiOS.xcframework.zip",
-            checksum: "e47bbf4f6df9b389b4f28005fd7504551fbd0e5ef07e70d29c9382774c9b8a2b"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CloneablePlatformiOS.xcframework.zip",
+            checksum: "7dc947e8296ab92f8d99e33fc88d1accf5848809edf34d9437cb3eaa8d5941e0"
         ),
         .binaryTarget(
             name: "CloneableCore", 
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/CloneableCore.xcframework.zip",
-            checksum: "1739d333baf9832152afc452d33d21b015c2dcae12ff63e49b9d1efcbecf6118"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CloneableCore.xcframework.zip",
+            checksum: "daad1605f7457209796036d4cf27237f7b670f10f68ef7288240e162757410df"
         ),
         .binaryTarget(
             name: "JXKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/JXKit.xcframework.zip", 
-            checksum: "a22a39c11ef0b3482f7aac3f7961859b70329096dd3356b450900d517b2fab28"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/JXKit.xcframework.zip", 
+            checksum: "b83cc842b8c65bd64e5389cac8e4f7504799f9a4833dd410f57bc2bc778e16a6"
         ),
         .binaryTarget(
             name: "CustomMenuKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/CustomMenuKit.xcframework.zip",
-            checksum: "16d857f7125c71ea2f6f558ea9e149b77be5afc9e8b3790c1160627888b09872"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CustomMenuKit.xcframework.zip",
+            checksum: "c55cf3b5ce78912933c691ef6e08f42747e3e5e47cd98b65cc727e94446491e4"
         ),
         .binaryTarget(
             name: "Alamofire",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/Alamofire.xcframework.zip",
-            checksum: "947557abd268df5cfbf6ccf6049396ad9c4b967f8a163c96d3e90422a064dc17"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/Alamofire.xcframework.zip",
+            checksum: "167b0d424b19e63c87c57bed56d5a30d39ea8716184395cc2abd27a95047a527"
         ),
         .binaryTarget(
             name: "Cloneable_Swift_Client",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/Cloneable_Swift_Client.xcframework.zip",
-            checksum: "a9f4d5067e94f9e84e44edaabf7cd5ce9fe4f4a40058e1ab96e81160e2d85a52"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/Cloneable_Swift_Client.xcframework.zip",
+            checksum: "67ec0e88524207f0638d379a6aaf352e8211eca1011c54d11160be3813a96ec6"
         ),
         .binaryTarget(
             name: "SQLite",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.1/SQLite.xcframework.zip",
-            checksum: "b5c0091b72b2e2e18fd2b0451103c39728fe11d6fb3f7c9386edd79e35caae6d"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/SQLite.xcframework.zip",
+            checksum: "675a46c895dab03c4296696ebf0e6de70666169d8671317c263f14b0c9f689fd"
         ),
         .target(
             name: "CloneableResources",


### PR DESCRIPTION
## SDK Release 1.0.3

Auto-generated Package.swift update for new SDK release.

### Changes
- Updated binary target URLs to point to release 1.0.3
- Updated checksums for all frameworks:
  - CloneablePlatformiOS: `7dc947e8296ab92f8d99e33fc88d1accf5848809edf34d9437cb3eaa8d5941e0`
  - CloneableCore: `daad1605f7457209796036d4cf27237f7b670f10f68ef7288240e162757410df`
  - JXKit: `b83cc842b8c65bd64e5389cac8e4f7504799f9a4833dd410f57bc2bc778e16a6`
  - CustomMenuKit: `c55cf3b5ce78912933c691ef6e08f42747e3e5e47cd98b65cc727e94446491e4`
  - Alamofire: `167b0d424b19e63c87c57bed56d5a30d39ea8716184395cc2abd27a95047a527`
  - Cloneable_Swift_Client: `67ec0e88524207f0638d379a6aaf352e8211eca1011c54d11160be3813a96ec6`
  - SQLite: `675a46c895dab03c4296696ebf0e6de70666169d8671317c263f14b0c9f689fd`

### Release Assets
All frameworks have been uploaded to: https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/tag/1.0.3

### Testing
- [ ] Verify release assets are accessible
- [ ] Test Package.swift syntax is valid  
- [ ] Confirm checksums match uploaded files

Released: 2025-07-22