### PR TITLE
Release 1.0.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,38 +24,38 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "CloneablePlatformiOS",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CloneablePlatformiOS.xcframework.zip",
-            checksum: "7dc947e8296ab92f8d99e33fc88d1accf5848809edf34d9437cb3eaa8d5941e0"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/CloneablePlatformiOS.xcframework.zip",
+            checksum: "49c77902810d030b0dbea8e23cc1a3fa5b97f82165ab375a68618f5623f09b24"
         ),
         .binaryTarget(
             name: "CloneableCore", 
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CloneableCore.xcframework.zip",
-            checksum: "daad1605f7457209796036d4cf27237f7b670f10f68ef7288240e162757410df"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/CloneableCore.xcframework.zip",
+            checksum: "902cc8afa5962d67638ba29f8ac7fd45fc589d5f8ae3e534131ff11dd8c6b3ce"
         ),
         .binaryTarget(
             name: "JXKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/JXKit.xcframework.zip", 
-            checksum: "b83cc842b8c65bd64e5389cac8e4f7504799f9a4833dd410f57bc2bc778e16a6"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/JXKit.xcframework.zip", 
+            checksum: "063694084ab7e2202d6a2111f049dcd0332c2f5f2aabea3e44d95f1b13306c8f"
         ),
         .binaryTarget(
             name: "CustomMenuKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/CustomMenuKit.xcframework.zip",
-            checksum: "c55cf3b5ce78912933c691ef6e08f42747e3e5e47cd98b65cc727e94446491e4"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/CustomMenuKit.xcframework.zip",
+            checksum: "3d73ed57052e13e990b086a87bff9333caff5edfca968a1c878c42633a7da47e"
         ),
         .binaryTarget(
             name: "Alamofire",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/Alamofire.xcframework.zip",
-            checksum: "167b0d424b19e63c87c57bed56d5a30d39ea8716184395cc2abd27a95047a527"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/Alamofire.xcframework.zip",
+            checksum: "1ae9251c8f9128815dc5d285e0b744e922623ea32b811ccdaf635627b8e47e20"
         ),
         .binaryTarget(
             name: "Cloneable_Swift_Client",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/Cloneable_Swift_Client.xcframework.zip",
-            checksum: "67ec0e88524207f0638d379a6aaf352e8211eca1011c54d11160be3813a96ec6"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/Cloneable_Swift_Client.xcframework.zip",
+            checksum: "45205eedfeaa728bd648a6dc5be936d8ae037e7ee0d24c11882c50d69b70e4b6"
         ),
         .binaryTarget(
             name: "SQLite",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.3/SQLite.xcframework.zip",
-            checksum: "675a46c895dab03c4296696ebf0e6de70666169d8671317c263f14b0c9f689fd"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.4/SQLite.xcframework.zip",
+            checksum: "05409fd358ca5cccf009b43b0919b9267a4b5564abc0d2e2d186156ed2afe51d"
         ),
         .target(
             name: "CloneableResources",


### PR DESCRIPTION
## SDK Release 1.0.4

Auto-generated Package.swift update for new SDK release.

### Changes
- Updated binary target URLs to point to release 1.0.4
- Updated checksums for all frameworks:
  - CloneablePlatformiOS: `49c77902810d030b0dbea8e23cc1a3fa5b97f82165ab375a68618f5623f09b24`
  - CloneableCore: `902cc8afa5962d67638ba29f8ac7fd45fc589d5f8ae3e534131ff11dd8c6b3ce`
  - JXKit: `063694084ab7e2202d6a2111f049dcd0332c2f5f2aabea3e44d95f1b13306c8f`
  - CustomMenuKit: `3d73ed57052e13e990b086a87bff9333caff5edfca968a1c878c42633a7da47e`
  - Alamofire: `1ae9251c8f9128815dc5d285e0b744e922623ea32b811ccdaf635627b8e47e20`
  - Cloneable_Swift_Client: `45205eedfeaa728bd648a6dc5be936d8ae037e7ee0d24c11882c50d69b70e4b6`
  - SQLite: `05409fd358ca5cccf009b43b0919b9267a4b5564abc0d2e2d186156ed2afe51d`

### Release Assets
All frameworks have been uploaded to: https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/tag/1.0.4

### Testing
- [ ] Verify release assets are accessible
- [ ] Test Package.swift syntax is valid  
- [ ] Confirm checksums match uploaded files

Released: 2025-07-28