### PR TITLE
Release 1.0.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,38 +24,38 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "CloneablePlatformiOS",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/CloneablePlatformiOS.xcframework.zip",
-            checksum: "d29d70379cde98b1367ce8af9b48e694d3a8e60bca19514502373ddd0d1e8349"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CloneablePlatformiOS.xcframework.zip",
+            checksum: "459358627e60533fa1d75ec53af1c5f74ad1257800ae3d311933a29d0ba9d86b"
         ),
         .binaryTarget(
             name: "CloneableCore", 
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/CloneableCore.xcframework.zip",
-            checksum: "b956ca8a4b1166b12ac8c63406df0a188072c61eac9839ccb8cf8793cf5c8c4e"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CloneableCore.xcframework.zip",
+            checksum: "5736c00e8faac41dc921921a017325caf0070b5bf16712008a35be11aa748d17"
         ),
         .binaryTarget(
             name: "JXKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/JXKit.xcframework.zip", 
-            checksum: "5006d77f6ecf0431c7041ed6493832c0cba35fcae6a1356a6dbca9bef937cb5b"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/JXKit.xcframework.zip", 
+            checksum: "afb25cf4cd968b14495e317251c42b482df00a57c89f2d7ce33c34e3ba3dd036"
         ),
         .binaryTarget(
             name: "CustomMenuKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/CustomMenuKit.xcframework.zip",
-            checksum: "f6536ff41c4b1d32286f4eded75318f48c69f302bce53cc03162a3b17cf9131a"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CustomMenuKit.xcframework.zip",
+            checksum: "f2933b19da959a37c157e7a3e0b877ba48f33cd6eccfc57baa2d2385c1142d77"
         ),
         .binaryTarget(
             name: "Alamofire",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/Alamofire.xcframework.zip",
-            checksum: "91bfdd6d699dbf9d2b7660d0110ff38621734b0fc82ad6d6a91192297dafa9e1"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/Alamofire.xcframework.zip",
+            checksum: "ca13fdb07e813e6250485a108bfbf4bdd493a2bf013d2cab468fdb94f6ab406d"
         ),
         .binaryTarget(
             name: "Cloneable_Swift_Client",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/Cloneable_Swift_Client.xcframework.zip",
-            checksum: "f8291d2703186821e78d205153063cb14f4ee07f220520a3d4e5287fe864a53d"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/Cloneable_Swift_Client.xcframework.zip",
+            checksum: "63099422c515416a73312c5aa393afac95c6b96f26105c587f7559cd13b53650"
         ),
         .binaryTarget(
             name: "SQLite",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.5/SQLite.xcframework.zip",
-            checksum: "e0d79c35fd77d0a5c24e7f8c73d1049aae162ad6c2fc390b02c8109402146184"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/SQLite.xcframework.zip",
+            checksum: "951ad10a53d0840bf3fd8e002ebaa42db72b37b61598852020c4921a4d0ae8ff"
         ),
         .target(
             name: "CloneableResources",


### PR DESCRIPTION
## SDK Release 1.0.6

Package.swift update for new SDK release.

### Changes
- Updated binary target URLs to point to release 1.0.6
- Updated checksums for all frameworks:
  - CloneablePlatformiOS: `459358627e60533fa1d75ec53af1c5f74ad1257800ae3d311933a29d0ba9d86b`
  - CloneableCore: `5736c00e8faac41dc921921a017325caf0070b5bf16712008a35be11aa748d17`
  - JXKit: `afb25cf4cd968b14495e317251c42b482df00a57c89f2d7ce33c34e3ba3dd036`
  - CustomMenuKit: `f2933b19da959a37c157e7a3e0b877ba48f33cd6eccfc57baa2d2385c1142d77`
  - Alamofire: `ca13fdb07e813e6250485a108bfbf4bdd493a2bf013d2cab468fdb94f6ab406d`
  - Cloneable_Swift_Client: `63099422c515416a73312c5aa393afac95c6b96f26105c587f7559cd13b53650`
  - SQLite: `951ad10a53d0840bf3fd8e002ebaa42db72b37b61598852020c4921a4d0ae8ff`

### Release Assets
All frameworks have been uploaded to: https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/tag/1.0.6

### Testing
- [x] Verify release assets are accessible
- [x] Test Package.swift syntax is valid  
- [x] Confirm checksums match uploaded files
- [x] All frameworks properly signed with Cloneable certificate

Released: 2025-08-28