### PR TITLE
Bump SDK to version 1.0.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,38 +24,38 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "CloneablePlatformiOS",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CloneablePlatformiOS.xcframework.zip",
-            checksum: "459358627e60533fa1d75ec53af1c5f74ad1257800ae3d311933a29d0ba9d86b"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/CloneablePlatformiOS.xcframework.zip",
+            checksum: "62cba7c3bb5eeb11e7bcd3770cfcf298805e0eff4e253685869e5154c9be2dde"
         ),
         .binaryTarget(
             name: "CloneableCore", 
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CloneableCore.xcframework.zip",
-            checksum: "5736c00e8faac41dc921921a017325caf0070b5bf16712008a35be11aa748d17"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/CloneableCore.xcframework.zip",
+            checksum: "3900abc1397bbf8ff95267a6061a1028e40efd913650837bad320e2d6e984d60"
         ),
         .binaryTarget(
             name: "JXKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/JXKit.xcframework.zip", 
-            checksum: "afb25cf4cd968b14495e317251c42b482df00a57c89f2d7ce33c34e3ba3dd036"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/JXKit.xcframework.zip", 
+            checksum: "0ebf6e2a6809ea1ad4cbed1fd72a0be11e0419aab281f06d3b6f61b6aea00137"
         ),
         .binaryTarget(
             name: "CustomMenuKit",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/CustomMenuKit.xcframework.zip",
-            checksum: "f2933b19da959a37c157e7a3e0b877ba48f33cd6eccfc57baa2d2385c1142d77"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/CustomMenuKit.xcframework.zip",
+            checksum: "c8169409f5045ab4f2540aadb2a4e318eca3c0ff8e0a99a77512e8f6df710263"
         ),
         .binaryTarget(
             name: "Alamofire",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/Alamofire.xcframework.zip",
-            checksum: "ca13fdb07e813e6250485a108bfbf4bdd493a2bf013d2cab468fdb94f6ab406d"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/Alamofire.xcframework.zip",
+            checksum: "7d8c094ebc3cd55b41d2569c860e3f59f2ebf240c48f0f748b9af745ac2856ee"
         ),
         .binaryTarget(
             name: "Cloneable_Swift_Client",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/Cloneable_Swift_Client.xcframework.zip",
-            checksum: "63099422c515416a73312c5aa393afac95c6b96f26105c587f7559cd13b53650"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/Cloneable_Swift_Client.xcframework.zip",
+            checksum: "328e73907163a81aea58ee44b5d2e05eda12b64e5ecf6bf1a10635d3cf085f1b"
         ),
         .binaryTarget(
             name: "SQLite",
-            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.6/SQLite.xcframework.zip",
-            checksum: "951ad10a53d0840bf3fd8e002ebaa42db72b37b61598852020c4921a4d0ae8ff"
+            url: "https://github.com/Cloneable-Inc/Cloneable-iOS-SDK/releases/download/1.0.7/SQLite.xcframework.zip",
+            checksum: "4beee514ea7dca7cf4ce40989f5387c21b2f93ea9d5f1af1fe410afd050a9c57"
         ),
         .target(
             name: "CloneableResources",


### PR DESCRIPTION
## Summary
- Updated all XCFramework URLs to point to version 1.0.7
- Updated checksums for signed XCFrameworks
- Includes async/await improvements from CloneablePlatformiOS 1.0.7

## Changes
- Refactored HOA editing to pure async pattern for better error handling
- Improved async/await implementation throughout workflow management
- Enhanced code quality and maintainability

## Release Notes
Available at https://github.com/Cloneable-Inc/CloneablePlatformSDK/releases/tag/1.0.7